### PR TITLE
feat: Add 'Before and After' section to homepage

### DIFF
--- a/src/components/BeforeAfter.astro
+++ b/src/components/BeforeAfter.astro
@@ -1,0 +1,76 @@
+---
+// src/components/BeforeAfter.astro
+// Komponen untuk menampilkan bagian "Before & After" transformasi material.
+
+const transformations = [
+  {
+    before: {
+      name: "Stainless Steel",
+      image: "https://images.unsplash.com/photo-1599305445671-ac29a0857862?q=80&w=2070&auto=format&fit=crop"
+    },
+    after: {
+      name: "Produk Jadi (Huruf Timbul)",
+      image: "https://images.unsplash.com/photo-1621934261462-3a5455242b10?q=80&w=1932&auto=format&fit=crop"
+    }
+  },
+  {
+    before: {
+      name: "ACP (Aluminium Composite Panel)",
+      image: "https://images.unsplash.com/photo-1542848134-1c1743865629?q=80&w=2070&auto=format&fit=crop"
+    },
+    after: {
+      name: "Produk Jadi (Fasad Gedung)",
+      image: "https://images.unsplash.com/photo-1588880331179-b0b54a326a95?q=80&w=1974&auto=format&fit=crop"
+    }
+  },
+  {
+    before: {
+      name: "MDF (Medium-Density Fibreboard)",
+      image: "https://images.unsplash.com/photo-1593642532400-2682810df593?q=80&w=2069&auto=format&fit=crop"
+    },
+    after: {
+      name: "Produk Jadi (Partisi Ruangan)",
+      image: "https://images.unsplash.com/photo-1618221195710-dd6b41faaea6?q=80&w=2000&auto=format&fit=crop"
+    }
+  }
+];
+---
+
+<section id="before-after" class="section-padding bg-silver-light">
+  <div class="container-custom">
+    <div class="text-center mb-20">
+      <div class="inline-flex items-center px-6 py-3 bg-blue-600/10 border border-blue-600/20 rounded-full text-blue-600 font-semibold text-sm mb-6">
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
+        Transformasi Material
+      </div>
+      <h2 class="heading-lg text-charcoal mb-8">Dari Bahan Mentah Menjadi Karya</h2>
+      <p class="text-xl text-graphite max-w-4xl mx-auto leading-relaxed">
+        Lihat bagaimana kami mengubah material berkualitas menjadi produk fungsional dan estetik dengan teknologi presisi kami.
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      {transformations.map((item) => (
+        <div class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-3 flex flex-col overflow-hidden border border-silver-mid/50">
+          <div class="relative">
+            <img src={item.before.image} alt={`Bahan ${item.before.name}`} class="w-full h-64 object-cover" loading="lazy" width="400" height="256"/>
+            <div class="absolute top-4 left-4 px-4 py-2 bg-charcoal/80 text-white text-sm font-semibold rounded-full backdrop-blur-sm">
+              SEBELUM
+            </div>
+          </div>
+          <div class="relative">
+            <img src={item.after.image} alt={`Produk jadi dari ${item.before.name}`} class="w-full h-64 object-cover" loading="lazy" width="400" height="256"/>
+            <div class="absolute top-4 left-4 px-4 py-2 bg-laser-green/90 text-white text-sm font-semibold rounded-full backdrop-blur-sm">
+              SESUDAH
+            </div>
+          </div>
+          <div class="p-6 text-center flex-grow flex flex-col">
+            <h3 class="text-xl font-bold text-charcoal mb-2">{item.before.name}</h3>
+            <p class="text-graphite text-sm">diubah menjadi</p>
+            <h4 class="text-lg font-semibold text-laser-green mt-1 flex-grow">{item.after.name}</h4>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import BaseLayout from '../components/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Hero from '../components/Hero.astro';
+import BeforeAfter from '../components/BeforeAfter.astro';
 import CTA from '../components/CTA.astro';
 
 // Import data terpusat dari constants.js
@@ -48,6 +49,7 @@ const reviewSchema = generateReviewSchema(TESTIMONIALS);
 
   <main>
     <Hero />
+    <BeforeAfter />
 
     <!-- Bagian Layanan -->
     <section id="services" class="section-padding bg-white">


### PR DESCRIPTION
This commit introduces a new 'Before and After' section to the homepage, placed directly below the hero section.

- A new `BeforeAfter.astro` component has been created to showcase the transformation of raw materials into finished products.
- The section displays three examples as requested: Stainless Steel, ACP, and MDF, using placeholder images from the internet.
- The new component is integrated into the main `index.astro` page.