### PR TITLE
refactor: Update images and button styles

### DIFF
--- a/src/components/BeforeAfter.astro
+++ b/src/components/BeforeAfter.astro
@@ -1,0 +1,76 @@
+---
+// src/components/BeforeAfter.astro
+// Komponen untuk menampilkan bagian "Before & After" transformasi material.
+
+const transformations = [
+  {
+    before: {
+      name: "Stainless Steel",
+      image: "/images/metal.webp"
+    },
+    after: {
+      name: "Produk Jadi (Huruf Timbul)",
+      image: "/images/stainlesssteel(2).webp"
+    }
+  },
+  {
+    before: {
+      name: "ACP (Aluminium Composite Panel)",
+      image: "/images/acp.webp"
+    },
+    after: {
+      name: "Produk Jadi (Fasad Gedung)",
+      image: "/images/acppro(2).webp"
+    }
+  },
+  {
+    before: {
+      name: "MDF (Medium-Density Fibreboard)",
+      image: "https://images.unsplash.com/photo-1593642532400-2682810df593?q=80&w=2069&auto=format&fit=crop"
+    },
+    after: {
+      name: "Produk Jadi (Partisi Ruangan)",
+      image: "https://images.unsplash.com/photo-1618221195710-dd6b41faaea6?q=80&w=2000&auto=format&fit=crop"
+    }
+  }
+];
+---
+
+<section id="before-after" class="section-padding bg-silver-light">
+  <div class="container-custom">
+    <div class="text-center mb-20">
+      <div class="inline-flex items-center px-6 py-3 bg-blue-600/10 border border-blue-600/20 rounded-full text-blue-600 font-semibold text-sm mb-6">
+        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
+        Transformasi Material
+      </div>
+      <h2 class="heading-lg text-charcoal mb-8">Dari Bahan Mentah Menjadi Karya</h2>
+      <p class="text-xl text-graphite max-w-4xl mx-auto leading-relaxed">
+        Lihat bagaimana kami mengubah material berkualitas menjadi produk fungsional dan estetik dengan teknologi presisi kami.
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      {transformations.map((item) => (
+        <div class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-3 flex flex-col overflow-hidden border border-silver-mid/50">
+          <div class="relative">
+            <img src={item.before.image} alt={`Bahan ${item.before.name}`} class="w-full h-64 object-cover" loading="lazy" width="400" height="256"/>
+            <div class="absolute top-4 left-4 px-4 py-2 bg-charcoal/80 text-white text-sm font-semibold rounded-full backdrop-blur-sm">
+              SEBELUM
+            </div>
+          </div>
+          <div class="relative">
+            <img src={item.after.image} alt={`Produk jadi dari ${item.before.name}`} class="w-full h-64 object-cover" loading="lazy" width="400" height="256"/>
+            <div class="absolute top-4 left-4 px-4 py-2 bg-laser-green/90 text-white text-sm font-semibold rounded-full backdrop-blur-sm">
+              SESUDAH
+            </div>
+          </div>
+          <div class="p-6 text-center flex-grow flex flex-col">
+            <h3 class="text-xl font-bold text-charcoal mb-2">{item.before.name}</h3>
+            <p class="text-graphite text-sm">diubah menjadi</p>
+            <h4 class="text-lg font-semibold text-laser-green mt-1 flex-grow">{item.after.name}</h4>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -112,9 +112,11 @@ const sizeClasses = getSizeClasses();
           rel={primaryLink.startsWith('http') ? 'noopener noreferrer' : ''}
           class={`
             inline-flex items-center justify-center px-8 py-4 text-lg font-semibold rounded-lg transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl w-full sm:w-auto
-            ${variant === 'minimal' 
-              ? 'bg-blue-600 hover:bg-blue-700 text-white' 
-              : 'bg-white hover:bg-gray-100 text-blue-600 hover:text-blue-700'
+            ${primaryLink.includes('whatsapp')
+              ? 'text-white bg-gradient-to-r from-laser-green to-laser-green-dark hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-laser-green-dark'
+              : (variant === 'minimal'
+                ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                : 'bg-white hover:bg-gray-100 text-blue-600 hover:text-blue-700')
             }
           `}
           data-gtm-id={primaryLink.includes('whatsapp') ? 'whatsapp-click' : undefined}

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -167,7 +167,7 @@ const filteredNavigation = NAVIGATION.filter(item => item.name !== "Kontak").map
             href={`https://api.whatsapp.com/send?phone=${SITE_CONFIG.whatsapp}&text=${encodeURIComponent("Halo, saya tertarik dengan jasa laser cutting. Bisa konsultasi gratis?")}`}
             target="_blank"
             rel="noopener noreferrer"
-            class="bg-green-600 hover:bg-green-700 text-white text-center py-2 px-4 rounded-lg text-sm font-medium flex items-center justify-center space-x-2"
+            class="text-white bg-gradient-to-r from-laser-green to-laser-green-dark hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-laser-green-dark text-center py-2 px-4 rounded-lg text-sm font-medium flex items-center justify-center space-x-2"
             data-gtm-id="whatsapp-click"
           >
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -69,7 +69,7 @@ const {
           href={primaryCTALink}
           target={primaryCTALink.startsWith('http') ? '_blank' : '_self'}
           rel={primaryCTALink.startsWith('http') ? 'noopener noreferrer' : ''}
-          class="btn-success text-lg px-8 py-4 w-full sm:w-auto transform hover:scale-105 shadow-xl"
+          class="text-white bg-gradient-to-r from-laser-green to-laser-green-dark hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-laser-green-dark font-semibold rounded-lg text-lg px-8 py-4 w-full sm:w-auto transform hover:scale-105 shadow-xl transition-all duration-300"
           data-gtm-id={primaryCTALink.includes('whatsapp') ? 'whatsapp-click' : undefined}
         >
           {primaryCTA}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import BaseLayout from '../components/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Hero from '../components/Hero.astro';
+import BeforeAfter from '../components/BeforeAfter.astro';
 import CTA from '../components/CTA.astro';
 
 // Import data terpusat dari constants.js
@@ -48,6 +49,7 @@ const reviewSchema = generateReviewSchema(TESTIMONIALS);
 
   <main>
     <Hero />
+    <BeforeAfter />
 
     <!-- Bagian Layanan -->
     <section id="services" class="section-padding bg-white">
@@ -125,7 +127,7 @@ const reviewSchema = generateReviewSchema(TESTIMONIALS);
 
         <!-- Tombol Konsultasi untuk Teknologi -->
         <div class="text-center mt-16">
-          <a href={`https://api.whatsapp.com/send?phone=${SITE_CONFIG.whatsapp}&text=${encodeURIComponent(WHATSAPP_MESSAGES.default)}`} target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center bg-gradient-to-r from-orange-500 to-red-500 text-white font-semibold text-lg px-10 py-5 rounded-xl shadow-xl hover:from-orange-600 hover:to-red-600 hover:shadow-2xl transform hover:scale-105 transition-all duration-300">
+          <a href={`https://api.whatsapp.com/send?phone=${SITE_CONFIG.whatsapp}&text=${encodeURIComponent(WHATSAPP_MESSAGES.default)}`} target="_blank" rel="noopener noreferrer" class="text-white bg-gradient-to-r from-laser-green to-laser-green-dark hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-laser-green-dark font-semibold rounded-lg text-lg px-10 py-5 shadow-xl transition-all duration-300 transform hover:scale-105">
             <svg class="w-6 h-6 mr-3" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893A11.821 11.821 0 0020.885 3.488"/></svg>
             Chat via WhatsApp
           </a>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -30,7 +30,9 @@ export default {
           700: '#334155',
           800: '#1e293b',
           900: '#0f172a',
-        }
+        },
+        'laser-green': '#00FF7F',
+        'laser-green-dark': '#00E673',
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
This commit addresses user feedback by:

1.  Updating the placeholder images in the 'Before and After' section with local images as specified by the user.
2.  Changing the color of all WhatsApp buttons to a 'laser green' gradient for a more consistent and aesthetic look.
3.  Defining the 'laser-green' color in the Tailwind CSS configuration to ensure it can be used globally.
4.  Updating the primary CTA button in the Hero section to use the new green gradient.