### PR TITLE
feat: Add Google Ads tracking tag

### DIFF
--- a/src/components/BaseLayout.astro
+++ b/src/components/BaseLayout.astro
@@ -119,6 +119,16 @@ const fullImage = new URL(image, siteUrl);
   })} />
   
   <meta name="theme-color" content="#0066FF" />
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-11545092315"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'AW-11545092315');
+  </script>
 </head>
 
 <body class="antialiased bg-white text-gray-900">


### PR DESCRIPTION
Adds the Google Ads tracking script (gtag.js) to the main layout file to enable conversion tracking.